### PR TITLE
Use ACL to ensure /etc/keys is readable by nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,8 @@ RUN useradd nginx && \
     chown -R nginx:nginx /usr/local/openresty/nginx/scgi_temp && \
     chown -R nginx:nginx /usr/share/GeoIP
 
+RUN setfacl -d -R -m u:nginx:r-X /etc/keys
+
 WORKDIR /usr/local/openresty
 
 ENTRYPOINT ["/go.sh"]


### PR DESCRIPTION
When mounting things into /etc/keys like foo.crt and foo.key, ensure
that the nginx user is able to read these files. We were getting
permissions issues when mounting certs into these locations and nginx
being unable to read them.