### PR TITLE
PP-2599 pay legacy logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Variables to control how to configure the proxy (can be set per location, see
 rules to be specified without downloading or mounting in a rule file.
 * `NAXSI_USE_DEFAULT_RULES` - If set to "FALSE" will delete the default rules file.
 * `ENABLE_UUID_PARAM` - If set to "FALSE", will NOT add a UUID url parameter to all requests. The Default will add this
- for easy tracking in down stream logs e.g. `nginxId=50c91049-667f-4286-c2f0-86b04b27d3f0`.
- If set to `HEADER` it will add `nginxId` to the headers, not append to the get params.
+ for easy tracking in down stream logs e.g. `X-Request-Id=50c91049-667f-4286-c2f0-86b04b27d3f0`.
+ If set to `HEADER` it will add `X-Request-Id` to the headers, not append to the get params.
 * `CLIENT_CERT_REQUIRED` - if set to `TRUE`, will deny access at this location, see [Client Certs](#client-certs).
 * `VERIFY_SERVER_CERT` - if set to `TRUE`, will verify the upstream server's TLS certificate is valid and signed by the CA, see [Verifying Upstream Server](#verifying-upstream-server).
 * `USE_UPSTREAM_CLIENT_CERT` - if set to `TRUE`, will use the set of upstream client certs when connecting upstream, see [Upstream Client Certs](#upstream-client-certs).
@@ -199,7 +199,7 @@ For more detail, see the [generated config](./docs/GeneratedConfigs.md#two-separ
 
 ##### One Server, Multiple locations
 
-The example below will proxy the same address for two locations but will disable the UUID (nginxId) parameter for the
+The example below will proxy the same address for two locations but will disable the UUID (X-Request-Id) parameter for the
 /about location only.
 
 See the [generated config](./docs/GeneratedConfigs.md#same-server-proxied) for below:

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -452,7 +452,7 @@ start_test "Test UUID GET param logging option works..." "${STD_CMD} \
            --link mockserver:mockserver "
 curl -sk https://${DOCKER_HOST_NAME}:${PORT}
 echo "Testing no logging of url params option works..."
-docker logs mockserver | grep '?nginxId='
+docker logs mockserver | grep '?X-Request-Id='
 docker logs ${INSTANCE} | grep '"nginx_uuid": "'
 
 start_test "Test UUID GET param logging option works with other params..." "${STD_CMD} \
@@ -463,7 +463,7 @@ start_test "Test UUID GET param logging option works with other params..." "${ST
            --link mockserver:mockserver "
 curl -sk https://${DOCKER_HOST_NAME}:${PORT}/?foo=bar
 echo "Testing no logging of url params option works..."
-docker logs mockserver | grep '?foo=bar&nginxId='
+docker logs mockserver | grep '?foo=bar&X-Request-Id='
 docker logs ${INSTANCE} | grep '"nginx_uuid": "'
 
 start_test "Test UUID header logging option works..." "${STD_CMD} \

--- a/enable_location.sh
+++ b/enable_location.sh
@@ -147,12 +147,12 @@ if [ "${ENABLE_UUID_PARAM}" == "FALSE" ]; then
     UUID_ARGS=''
     msg "Auto UUID request parameter disabled for location ${LOCATION_ID}."
 elif [ "${ENABLE_UUID_PARAM}" == "HEADER" ]; then
-    UUID_ARGS='proxy_set_header nginxId $uuidopt;'
+    UUID_ARGS='proxy_set_header X-Request-Id $uuidopt;'
     # Ensure nginx enables this globaly
     msg "Auto UUID request header enabled for location ${LOCATION_ID}."
     touch ${UUID_FILE}
 else
-    UUID_ARGS='if ($is_args) {set $args $args&nginxId=$uuidopt;} if ($is_args = "") { set $args nginxId=$uuidopt;}'
+    UUID_ARGS='if ($is_args) {set $args $args&X-Request-Id=$uuidopt;} if ($is_args = "") { set $args X-Request-Id=$uuidopt;}'
     # Ensure nginx enables this globaly
     msg "Auto UUID request parameter enabled for location ${LOCATION_ID}."
     touch ${UUID_FILE}

--- a/go.sh
+++ b/go.sh
@@ -122,7 +122,7 @@ else
 fi
 
 case "${LOG_FORMAT_NAME}" in
-    "json" | "text")
+    "json" | "text" | "govuk_pay_legacy")
         msg "Logging set to ${LOG_FORMAT_NAME}"
 
         if [ "${NO_LOGGING_URL_PARAMS}" ]; then

--- a/logging.conf
+++ b/logging.conf
@@ -32,3 +32,10 @@ log_format extended_json '{'
   '"ssl_client_verify": "$ssl_client_verify", '
   '"ssl_client_s_dn": "$ssl_client_s_dn" '
   '}';
+
+# GOV.UK Pay legacy logging. This is just a change to make migration
+# to using this container easier. We have raised a ticket to revisit
+# and use JSON format for structured logs.
+log_format extended_govuk_pay_legacy '$server_name:$server_port $uuid $http_x_forwarded_for $remote_addr $remote_user [$time_local] '
+'"$request" $status $body_bytes_sent $request_time $http_x_forwarded_proto "$http_referer" '
+'"$http_user_agent"';

--- a/lua/set_uuid.lua
+++ b/lua/set_uuid.lua
@@ -6,6 +6,6 @@ else
     uuid.randomseed(socket.gettime()*10000)
     local uuid_str = uuid()
     ngx.var.uuid = uuid_str
-    ngx.var.uuid_log_opt = " nginxId=" .. uuid_str
+    ngx.var.uuid_log_opt = " X-Request-Id=" .. uuid_str
     return uuid_str
 end

--- a/test-servers.yaml
+++ b/test-servers.yaml
@@ -15,16 +15,16 @@
      body: '200 is OK :)'
  - name: All OK with nginxID
    request:
-     uri: /?nginxId=foo
-     regexuri: \/?nginxId=[a-z]+
+     uri: /?X-Request-Id=foo
+     regexuri: \/?X-Request-Id=[a-z]+
      method: GET
    response:
      code: 200
      body: '200 is OK :)'
  - name: All OK with nginxID and other get params
    request:
-     uri: /?foo=bar&nginxId=foo
-     regexuri: \/?foo=bar&nginxId=[a-z]+
+     uri: /?foo=bar&X-Request-Id=foo
+     regexuri: \/?foo=bar&X-Request-Id=[a-z]+
      method: GET
    response:
      code: 200


### PR DESCRIPTION
See commits. This gets us most of the way to having the same logging format as current Nginx on the host. Some fields aren't populated, like $server_name, which we will need to look into later.